### PR TITLE
Move "chai" to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "chai": "latest"
   },
   "devDependencies": {
     "mocha": "latest",
-    "cover": "latest"
+    "cover": "latest",
+    "chai": "latest"
   }
 }


### PR DESCRIPTION
`chai` is only required for testing, not in production.